### PR TITLE
バリデーションに引っかかるように書籍を登録した際、レンダリングのエラーが出るバグを解消した。

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -8,6 +8,7 @@ class BooksController < ApplicationController
 
   def create
     @book = current_user.books.new(book_params)
+    @books = current_user.books.order(created_at: :desc)
 
     if @book.save
       redirect_to books_url, notice: '書籍を登録しました'


### PR DESCRIPTION
Ref: #63 

レンダリング時に@booksにnilが入ってるためエラーが起きていたのでcreateアクションで書籍の全てのインスタンスを作成するようにした。

バリデーションエラーの時も書籍一覧画面が正常にレンダリングされるようになった。

![image](https://user-images.githubusercontent.com/57053236/150997743-45755b74-2717-4741-9aac-250fafbe60b8.png)
