### PR TITLE
写真がないときのレンダリングエラーを解消した

### DIFF
--- a/app/views/photos/index.html.slim
+++ b/app/views/photos/index.html.slim
@@ -1,9 +1,10 @@
 h2.title.is-2 = @book.title
-p = "投稿日: #{l(@photos.first.created_at)}"
+p = "投稿日: #{l(@photos.first.created_at)}" if @phots.present?
 = render 'form', photo: @photo
 p = "写真の枚数: #{@photos.count}枚"
 hr
-ul.columns
-  - @photos.each do |photo|
-    li.column = image_tag photo.image_url if photo.image
-      = photo.created_at
+
+= if @photos.present?
+  ul.columns
+    - @photos.each do |photo|
+      li.column = image_tag photo.image_url if photo.image


### PR DESCRIPTION
Ref: #22 

写真が1枚もない時の分岐条件を記述していなかったためエラーが起きていた。
写真が一枚もない時の条件分岐を追加してエラーを回避した。

## 修正前
![image](https://user-images.githubusercontent.com/57053236/151700045-61ed0a36-a003-4115-990d-76dda94db0cb.png)

## 修正後
![image](https://user-images.githubusercontent.com/57053236/151700081-31a126ec-7611-496b-b214-76eefbf103a7.png)
