### PR TITLE
写真の最終投稿日を日付 + (何時間前）という表示に変更した

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,7 +3,8 @@
 module ApplicationHelper
   def last_update_of_photo(book)
     return '' unless book.photos.exists?
-    "#{l(book.photos.last.updated_at, format: :date)}" \
+
+    l(book.photos.last.updated_at, format: :date).to_s \
     + "(#{time_ago_in_words(book.photos.last.updated_at)}前)"
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def last_update_of_photo(book)
+    return '' unless book.photos.exists?
+    "#{l(book.photos.last.updated_at, format: :date)}" \
+    + "(#{time_ago_in_words(book.photos.last.updated_at)}前)"
+  end
 end

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -8,4 +8,4 @@ ul
   - @books.each do |book|
     .columns
       li.column = link_to book.title, book_path(book)
-      li.column = book.created_at
+      li.column = "#{l(book.created_at, format: :date)}" + "(#{time_ago_in_words(book.created_at)}前)"

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -8,4 +8,5 @@ ul
   - @books.each do |book|
     .columns
       li.column = link_to book.title, book_path(book)
-      li.column = "#{l(book.created_at, format: :date)}" + "(#{time_ago_in_words(book.created_at)}前)"
+      li.column
+        = last_update_of_photo(book)

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -1,7 +1,8 @@
 h2.title.is-2 = @book.title
 = link_to '書籍の編集', edit_book_path(@book), class: 'button'
 hr
-p = "投稿日: #{l(@photos.first.created_at, format: :long)}" if @photos.present?
+-  if @photos.present?
+  p = "投稿日: #{last_update_of_photo(@book)}"
 p = "写真の枚数: #{@photos.count}枚"
 = link_to '写真投稿', new_book_photos_path(@book), class: 'button'
 hr

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,3 +5,7 @@ ja:
     attributes:
       book:
         title: 書籍名
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"
+      date: "%Y年%m月%d日"


### PR DESCRIPTION
Refs: #86 

写真の最終投稿日の表示について、日付と（何時間前）あるいは（何日前）という表示形式に変更した。

変更箇所は

- 書籍一覧画面
- 書籍詳細画面（写真一覧画面)

## 変更前
<書籍一覧>
![image](https://user-images.githubusercontent.com/57053236/152066360-2ecf4a49-02e3-42a0-85a9-4405cf3585eb.png)

<書籍詳細(写真一覧)>
![image](https://user-images.githubusercontent.com/57053236/152066315-7442d1e7-4073-4308-9183-d1bba8353770.png)


## 変更後
<書籍一覧>
![image](https://user-images.githubusercontent.com/57053236/152066761-5eb799d5-5751-44ee-b275-91b8ee9da03a.png)

<書籍詳細(写真一覧)>
![image](https://user-images.githubusercontent.com/57053236/152066263-09d17b72-20ea-4760-81e9-7bf980b4b979.png)
