### PR TITLE
ファイルアップローダーでファイルを選択したとき、選択したファイル名が表示されるようにした。

### DIFF
--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -6,10 +6,9 @@ class PhotosController < ApplicationController
   end
 
   def create
-    photo = Book.find(params[:book_id]).photos.new(photo_params)
-
-    if photo.save
-      redirect_to book_url(photo.book), notice: '写真を投稿しました'
+    @photo = Book.find(params[:book_id]).photos.new(photo_params)
+    if @photo.save
+      redirect_to book_url(@photo.book), notice: '写真を投稿しました'
     else
       render :new
     end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -3,4 +3,6 @@
 class Photo < ApplicationRecord
   include ImageUploader::Attachment(:image)
   belongs_to :book
+
+  validates_presence_of :image, message: 'を選択してください'
 end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -4,5 +4,5 @@ class Photo < ApplicationRecord
   include ImageUploader::Attachment(:image)
   belongs_to :book
 
-  validates_presence_of :image, message: 'を選択してください'
+  validates :image, presence: { message: 'を選択してください' }
 end

--- a/app/views/books/edit.html.slim
+++ b/app/views/books/edit.html.slim
@@ -1,4 +1,4 @@
 h2.title.is-2 = @book.title
 
 = render 'form', book: @book
-= link_to '戻る', books_path
+= link_to '戻る', book_path(@book)

--- a/app/views/photos/_form.html.slim
+++ b/app/views/photos/_form.html.slim
@@ -1,13 +1,6 @@
 = form_with(model: [:book, photo]) do |f|
   .field
-    .control.file.is-boxed
-      = f.label :image, class: 'file-label'
-        = f.file_field :image, class: 'file-input'
-        span.file-cta
-          span.file-icon
-            i.fas.fa-upload
-          span.file-label
-            | Chose a file
-  .field
     .control
-    = f.submit class: 'button'
+      = f.label :image, class: 'file-label'
+      = f.file_field :image, class: 'file'
+  = f.submit '投稿する', class: 'button'

--- a/app/views/photos/_form.html.slim
+++ b/app/views/photos/_form.html.slim
@@ -1,6 +1,13 @@
-= form_with(model: [:book, photo]) do |f|
+= form_with(model: [photo.book, photo]) do |f|
+  - if photo.errors.any?
+    #error_explanation.message.is-light
+      ul
+        - photo.errors.full_messages.each do |message|
+          li.message-body = message
   .field
     .control
       = f.label :image, class: 'file-label'
+      = image_tag f.object.image_url if f.object.cached_image_data
+      = f.hidden_field :image, value: f.object.cached_image_data
       = f.file_field :image, class: 'file'
   = f.submit '投稿する', class: 'button'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,9 +2,12 @@ ja:
   activerecord:
     models:
       book: 書籍
+      photo: 写真
     attributes:
       book:
         title: 書籍名
+      photo:
+        image: 写真
   time:
     formats:
       default: "%Y/%m/%d %H:%M:%S"


### PR DESCRIPTION
Refs: #70 #85
ファイルアップローダーはbulmaでデザインしていた。
bulmaだとJavaScriptでファイル名を取得してこないといけなくて、やってみたがうまくいかなかったため。
bulmaを外してみた。

また、ファイルアップローダーでファイルを選択せずに「投稿」ボタンを押したときバリデーションが効くようにした。

## 変更前
![image](https://user-images.githubusercontent.com/57053236/152112300-c7a047b1-f3aa-4ce1-a941-1b63f7b1c026.png)

## 変更後
![image](https://user-images.githubusercontent.com/57053236/152112473-f3fcc4cd-d41e-4239-ab16-db44eb83cb24.png)

![image](https://user-images.githubusercontent.com/57053236/152276765-f3754311-0738-44a8-8fdb-d9b48306b3e2.png)

## 備考
ファイルアップローダーはCSSでデザインした方が良い？