### PR TITLE
HTMLのタイトルを動的に設定できるようにした

### DIFF
--- a/app/views/books/edit.html.slim
+++ b/app/views/books/edit.html.slim
@@ -1,3 +1,5 @@
+- content_for(:html_title) { '書籍名の編集' }
+
 h2.title.is-2 = @book.title
 
 = render 'form', book: @book

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -1,3 +1,5 @@
+- content_for(:html_title) { '書籍の一覧' }
+
 h2.title.is-2 書籍の一覧
 
 = render 'form', book: @book

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -1,3 +1,4 @@
+- content_for(:html_title) { "投稿した写真(#{@book.title})" }
 h2.title.is-2 = @book.title
 = link_to '書籍の編集', edit_book_path(@book), class: 'button'
 hr

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -2,7 +2,7 @@ doctype html
 html
   head
     title
-      | Reread
+      = content_for?(:html_title) ? "#{yield(:html_title)} | reRead" : 'reRead'
     meta[name="viewport" content="width=device-width,initial-scale=1"]
     = csrf_meta_tags
     = csp_meta_tag

--- a/app/views/photos/new.html.slim
+++ b/app/views/photos/new.html.slim
@@ -1,3 +1,5 @@
+- content_for(:html_title) { '写真の投稿' }
+
 h2.title.is-2 = @photo.book.title
 hr
 h3.subtitle.is-4 写真の投稿


### PR DESCRIPTION
Refs: #77 

## 概要
`content_for`を用いてHTMLのタイトル欄をページごとに設定できるようにViewファイルを修正した。

![image](https://user-images.githubusercontent.com/57053236/152291458-b9e56619-ac48-4bec-8d6e-4ca79f312fb4.png)
