### PR TITLE
ログインしているユーザーのルートパスを書籍の一覧ページに変更した

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -3,5 +3,7 @@
 class WelcomeController < ApplicationController
   skip_before_action :authenticate
 
-  def index; end
+  def index
+    redirect_to books_path if logged_in?
+  end
 end


### PR DESCRIPTION
Refs: #77 

## やったこと
ログインしているユーザーがwelcomeページに飛んだときエラーが出ていたので、そもそもログインしているユーザーは書籍一覧画面をルートとなるように変更した。

