### PR TITLE
アカウント削除機能を実装した

### DIFF
--- a/app/controllers/retirements_controller.rb
+++ b/app/controllers/retirements_controller.rb
@@ -1,0 +1,11 @@
+class RetirementsController < ApplicationController
+  def new
+  end
+
+  def create
+    if current_user.destroy
+      reset_session
+      redirect_to root_path, notice: 'アカウントを削除しました'
+    end
+  end
+end

--- a/app/controllers/retirements_controller.rb
+++ b/app/controllers/retirements_controller.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
+
 class RetirementsController < ApplicationController
-  def new
-  end
+  def new; end
 
   def create
-    if current_user.destroy
-      reset_session
-      redirect_to root_path, notice: 'アカウントを削除しました'
-    end
+    return unless current_user.destroy
+
+    reset_session
+    redirect_to root_path, notice: 'アカウントを削除しました'
   end
 end

--- a/app/helpers/retirements_helper.rb
+++ b/app/helpers/retirements_helper.rb
@@ -1,0 +1,2 @@
+module RetirementsHelper
+end

--- a/app/helpers/retirements_helper.rb
+++ b/app/helpers/retirements_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module RetirementsHelper
 end

--- a/app/views/retirements/new.html.slim
+++ b/app/views/retirements/new.html.slim
@@ -4,4 +4,3 @@ p.my-4 アカウントを削除した場合、登録した書籍や写真が全�
 
 = link_to 'アカウントを削除する', retirement_path, method: :post,
   class: 'button is-danger is-light', data: { confirm: '本当に削除しますか？' }
-

--- a/app/views/retirements/new.html.slim
+++ b/app/views/retirements/new.html.slim
@@ -1,0 +1,7 @@
+h2.title.is-2.my-6 アカウント削除確認画面
+
+p.my-4 アカウントを削除した場合、登録した書籍や写真が全て削除されます。
+
+= link_to 'アカウントを削除する', retirement_path, method: :post,
+  class: 'button is-danger is-light', data: { confirm: '本当に削除しますか？' }
+

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -5,5 +5,6 @@ nav.navbar.is-light
     - if logged_in?
       = image_tag @current_user.image_url, width: 50, height: 30
       = link_to 'ログアウト', logout_path, class: 'navbar-item', method: :delete
+      = link_to 'アカウント削除', new_retirement_path, class: 'navbar-item'
     - else
       = link_to 'GitHubでログイン', '/auth/github', class: 'navbar-item', method: :post

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   get '/auth/:provider/callback', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
 
+  resource :retirement
+
   resources :books, except: %i(new) do
     resource :photos, only: %i(new create)
   end

--- a/spec/requests/retirements_spec.rb
+++ b/spec/requests/retirements_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Retirements", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/retirements_spec.rb
+++ b/spec/requests/retirements_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "Retirements", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
-  end
-end

--- a/spec/system/retirements_spec.rb
+++ b/spec/system/retirements_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'Retirements', type: :system do
+  let(:user) { FactoryBot.create(:user) }
+
+  describe 'アカウント' do
+    context 'ログインしているとき', js: true do
+      it '削除できる' do
+        sign_in_as user
+        visit new_retirement_path
+
+        click_on 'アカウントを削除する'
+        expect do
+          expect(page.accept_confirm).to eq '本当に削除しますか？'
+          expect(page).to have_content 'アカウントを削除しました'
+        end.to change{ User.count }.by(-1)
+
+        expect(current_path).to eq root_path
+        expect(page).to have_content 'Welcome'
+      end
+    end
+
+    context 'ログインしていないとき' do
+      it '削除できない' do
+        visit new_retirement_path
+
+        expect(current_path).to eq root_path
+        expect(page).to have_content 'Welcome'
+      end
+    end
+  end
+end

--- a/spec/system/retirements_spec.rb
+++ b/spec/system/retirements_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe 'Retirements', type: :system do
@@ -13,7 +15,7 @@ RSpec.describe 'Retirements', type: :system do
         expect do
           expect(page.accept_confirm).to eq '本当に削除しますか？'
           expect(page).to have_content 'アカウントを削除しました'
-        end.to change{ User.count }.by(-1)
+        end.to change { User.count }.by(-1)
 
         expect(current_path).to eq root_path
         expect(page).to have_content 'Welcome'


### PR DESCRIPTION
Refs: #83 

## 概要
ログインしているユーザが自分アカウントを削除できるようにした。
アカウントを削除した場合、登録した書籍やそれに紐づいている写真などデータが全て削除されるので確認画面を設けた。

![image](https://user-images.githubusercontent.com/57053236/153013081-ee6c05fb-54bd-4407-ac3f-137bc44e1338.png)
![image](https://user-images.githubusercontent.com/57053236/153013246-40c3c9ae-4b86-4ba6-84d8-f1c712c1c586.png)
