### PR TITLE
写真のサイズを小さくできるようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
+ gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
- gem 'image_processing', '~> 1.2'
+gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,9 @@ GEM
     httpclient (2.8.3)
     i18n (1.9.1)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     io-wait (0.2.1)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
@@ -201,6 +204,7 @@ GEM
     matrix (0.4.2)
     memoist (0.16.2)
     method_source (1.0.0)
+    mini_magick (4.11.0)
     mini_mime (1.1.2)
     minitest (5.15.0)
     msgpack (1.4.4)
@@ -351,6 +355,8 @@ GEM
     rubocop-rspec (2.8.0)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
@@ -442,6 +448,7 @@ DEPENDENCIES
   google-api-client
   google-apis-calendar_v3 (~> 0.15.0)
   html2slim
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   kaminari
   launchy

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,6 +1,25 @@
 # frozen_string_literal: true
 
+require 'image_processing/mini_magick'
 class ImageUploader < Shrine
+  plugin :processing # allows hooking into promoting
+  plugin :versions   # enable Shrine to handle a hash of files
+  plugin :delete_raw # delete processed files after uploading
+
+  process(:store) do |io, _context|
+    versions = { original: io } # retain original
+
+    io.download do |original|
+      pipeline = ImageProcessing::MiniMagick.source(original)
+
+      versions[:large]  = pipeline.resize_to_limit!(800, 800)
+      versions[:medium] = pipeline.resize_to_limit!(500, 500)
+      versions[:small]  = pipeline.resize_to_limit!(150, 150)
+    end
+
+    versions # return the hash of processed files
+  end
+
   Attacher.validate do
     validate_max_size 5 * 1024 * 1024, message: 'サイズは5.0MB以内で選択してください'
     validate_mime_type %w[image/jpeg image/png image/webp image/tiff],

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -13,7 +13,7 @@ hr
   ul.columns
     - @photos.each do |photo|
       li class="column image-#{photo.id}"
-        = image_tag photo.image_url if photo.image
+        = image_tag photo.image[:medium].url if photo.image
 = link_to '戻る', books_path
 = link_to 'この書籍を削除する', book_path(@book), method: :delete,
   data: { confirm: '投稿した写真も削除されます。よろしいですか？' }, class: 'button'


### PR DESCRIPTION
リサイズなしだった場合、画面をはみ出て写真が表示されていたため、写真のサイズを変更できるようにした。

## 変更後
サイズ`medium`
![image](https://user-images.githubusercontent.com/57053236/156721442-21fe9145-7940-45fd-a982-56468359a7f5.png)

サイズ`small`
![image](https://user-images.githubusercontent.com/57053236/156721663-37090557-a3b0-45f3-9d9a-c2e1bbdce677.png)
