### PR TITLE
写真一覧画面のレイアウトを整えた

### DIFF
--- a/app/javascript/packs/application.sass
+++ b/app/javascript/packs/application.sass
@@ -1,3 +1,4 @@
 @import '../styles/_body.sass'
 @import '../styles/_header.sass'
+@import '../styles/_photo'
 @import '~bulma/css/bulma.min'

--- a/app/javascript/styles/_photo.sass
+++ b/app/javascript/styles/_photo.sass
@@ -1,0 +1,12 @@
+@charset 'UTF-8'
+
+.book-info
+  border-bottom: 2px solid #eee
+  h1.title
+    margin: 0px 8px 0px 0px
+
+.photo-info
+  border-bottom: 2px solid #eee
+
+.photo-index p
+  margin-top: 100px

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -13,7 +13,7 @@ class ImageUploader < Shrine
       pipeline = ImageProcessing::MiniMagick.source(original)
 
       versions[:large]  = pipeline.resize_to_limit!(800, 800)
-      versions[:medium] = pipeline.resize_to_limit!(500, 500)
+      versions[:medium] = pipeline.resize_to_limit!(400, 400)
       versions[:small]  = pipeline.resize_to_limit!(150, 150)
     end
 

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -1,6 +1,6 @@
 - content_for(:html_title) { '書籍の一覧' }
 
-h2.title.is-4 書籍の一覧
+h1.title.is-4 書籍の一覧
 
 = render 'form', book: @book
 

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -5,7 +5,10 @@
     h1.title.is-3 = @book.title
     = link_to '編集', edit_book_path(@book), class: 'button is-small is-responsive'
   .div
-    = link_to '写真投稿', new_book_photos_path(@book), class: 'button is-warning is-rounded'
+    = link_to new_book_photos_path(@book), class: 'button is-primary is-rounded' do
+      span.icon.mr-1
+        i.fas.fa-camera
+      = '写真投稿'
 
 .photo-info.is-flex.is-justify-content-space-between.is-align-items-center.py-2
   -  if @photos.present?
@@ -17,13 +20,12 @@
   .google-button.has-text-right
     = link_to 'Googleカレンダーに再読日を設定する', new_book_read_histories_path(@book), class: 'button is-small'
 
-.photo-index
+.photo-index.is-flex.is-flex-wrap-wrap.is-align-content-flex-start
   - if @photos.present?
     - @photos.each do |photo|
-      .card.my-2
-        .card-image
-          - if photo.image
-            = image_tag photo.image[:medium].url, class: "image-#{photo.id}"
+      .photo-section.m-3
+        - if photo.image
+          = image_tag photo.image[:medium].url, class: "image-#{photo.id}"
   - else
     p.has-text-centered = '写真の投稿はまだありません'
 

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -1,19 +1,33 @@
 - content_for(:html_title) { "投稿した写真(#{@book.title})" }
-h2.title.is-2 = @book.title
-= link_to '書籍の編集', edit_book_path(@book), class: 'button'
-hr
--  if @photos.present?
-  p = "投稿日: #{last_update_of_photo(@book)}"
-p = "写真の枚数: #{@photos.count}枚"
-= link_to '写真投稿', new_book_photos_path(@book), class: 'button'
-= link_to 'Googleカレンダーに再読日を設定する', new_book_read_histories_path(@book), class: 'button'
-hr
 
-- if @photos.present?
-  ul.columns
+.book-info.is-flex.is-justify-content-space-between.is-align-items-center.py-2
+  .book-title.is-flex.is-align-items-center
+    h1.title.is-3 = @book.title
+    = link_to '編集', edit_book_path(@book), class: 'button is-small is-responsive'
+  .div
+    = link_to '写真投稿', new_book_photos_path(@book), class: 'button is-warning is-rounded'
+
+.photo-info.is-flex.is-justify-content-space-between.is-align-items-center.py-2
+  -  if @photos.present?
+    p = "投稿日: #{last_update_of_photo(@book)}"
+  - else
+    p = '投稿日: --------'
+  .photo-count
+    p = "写真の枚数: #{@photos.count}枚"
+  .google-button.has-text-right
+    = link_to 'Googleカレンダーに再読日を設定する', new_book_read_histories_path(@book), class: 'button is-small'
+
+.photo-index
+  - if @photos.present?
     - @photos.each do |photo|
-      li class="column image-#{photo.id}"
-        = image_tag photo.image[:medium].url if photo.image
-= link_to '戻る', books_path
-= link_to 'この書籍を削除する', book_path(@book), method: :delete,
-  data: { confirm: '投稿した写真も削除されます。よろしいですか？' }, class: 'button'
+      .card.my-2
+        .card-image
+          - if photo.image
+            = image_tag photo.image[:medium].url, class: "image-#{photo.id}"
+  - else
+    p.has-text-centered = '写真の投稿はまだありません'
+
+.is-flex.is-justify-content-space-between
+  = link_to '戻る', books_path
+  = link_to 'この書籍を削除する', book_path(@book), method: :delete,
+      data: { confirm: '投稿した写真も削除されます。よろしいですか？' }, class: 'button is-small'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -12,7 +12,7 @@ html
   body
     header
       = render 'shared/header'
-    main.p-5
+    main.px-6.pt-3
       - if flash.notice
         .notification.is-success.is-light
           = flash.notice


### PR DESCRIPTION
Refs: #110 

## 変更前
![image](https://user-images.githubusercontent.com/57053236/156870827-75f26558-5676-4b2b-bd14-ca6f1e14adaa.png)

## 変更後
![image](https://user-images.githubusercontent.com/57053236/156870805-e6fc5402-9fc3-4384-aada-1a7cb7d57fdd.png)

## 主な変更点
- 書籍情報、写真の情報をコンパクトにした（写真の常時領域を増やすため）
- 重要度の低いボタンを小さくした
- 写真投稿ボタンにアイコンをつけた