### PR TITLE
写真が投稿されていないときのページのレイアウトを変更した。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,6 @@ gem 'omniauth-google-oauth2'
 gem 'omniauth-rails_csrf_protection'
 gem 'rails-i18n'
 gem 'shrine'
+gem 'shrine-cloudinary'
 gem 'slim-rails'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
-gem 'shrine-cloudinary'

--- a/app/javascript/styles/_photo.sass
+++ b/app/javascript/styles/_photo.sass
@@ -15,3 +15,6 @@
   width: 400px
   height: 400px
   object-fit: cover
+
+.blank-page
+  margin: 100px 0

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -20,7 +20,7 @@
   .google-button.has-text-right
     = link_to 'Googleカレンダーに再読日を設定する', new_book_read_histories_path(@book), class: 'button is-small'
 
-div class="photo-index is-flex is-flex-wrap-wrap is-align-content-flex-start #{'is-justify-content-center' unless @photos.present?}"
+div class="photo-index is-flex is-flex-wrap-wrap is-align-content-flex-start #{'is-justify-content-center' if @photos.blank?}"
   - if @photos.present?
     - @photos.each do |photo|
       .photo-section.m-3

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -20,14 +20,23 @@
   .google-button.has-text-right
     = link_to 'Googleカレンダーに再読日を設定する', new_book_read_histories_path(@book), class: 'button is-small'
 
-.photo-index.is-flex.is-flex-wrap-wrap.is-align-content-flex-start
+div class="photo-index is-flex is-flex-wrap-wrap is-align-content-flex-start #{'is-justify-content-center' unless @photos.present?}"
   - if @photos.present?
     - @photos.each do |photo|
       .photo-section.m-3
         - if photo.image
           = image_tag photo.image[:medium].url, class: "image-#{photo.id}"
   - else
-    p.has-text-centered = '写真の投稿はまだありません'
+    .blank-page.has-text-centered.has-text-grey
+      .o-empty-message__text
+        | 写真の投稿はまだありません
+      .is-size-1
+        i.far.fa-sad-tear
+      .div
+        = link_to new_book_photos_path(@book), class: 'button is-primary is-rounded' do
+          span.icon.mr-1
+            i.fas.fa-camera
+          = '写真投稿'
 
 .is-flex.is-justify-content-space-between
   = link_to '戻る', books_path


### PR DESCRIPTION
Refs: #124 

## やったこと
- 写真の投稿はまだありませんという文言を中央よせにした
- 写真の投稿がないとき、泣き顔のアイコンを表示させた
- 写真投稿ボタンを設置した

## 変更前
![image](https://user-images.githubusercontent.com/57053236/157401088-770c88aa-c322-4956-9432-44a79fbecc46.png)

## 変更後
![image](https://user-images.githubusercontent.com/57053236/157400934-d2dbfd46-7fe1-40bb-9cd7-386401d4b43b.png)
