### PR TITLE
書籍一覧画面のレイアウトを整えた

### DIFF
--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -7,9 +7,22 @@ h1.title.is-4 書籍の一覧
 hr
 .mb-3
   = paginate @books
-ul
-  - @books.each do |book|
-    .columns
-      li.column = link_to book.title, book_path(book)
-      li.column
-        = last_update_of_photo(book)
+- if @books.present?
+  table.table.is-fullwidth
+    thead
+      tr
+        th = Book.human_attribute_name(:title)
+        th = Photo.human_attribute_name(:updated_at)
+        th = ReadHistory.human_attribute_name(:read_back_at)
+    tbody
+      - @books.each do |book|
+        tr
+          td = link_to book.title, book_path(book)
+          td = last_update_of_photo(book)
+          td = l(book.read_histories.last.read_back_at, format: :date) if book.read_histories.present?
+- else
+  .blank-page.has-text-centered.has-text-grey
+      .o-empty-message__text
+        | 書籍はまだありません
+      .is-size-1
+        i.far.fa-sad-tear

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,6 +9,7 @@ ja:
         title: 書籍名
       photo:
         image: 写真
+        updated_at: 投稿日
       read_history:
         summary: サマリー
         read_back_at: 読み返す日

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,3 +18,6 @@ ja:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
       date: "%Y年%m月%d日"
+  date:
+    formats:
+      date: "%Y年%m月%d日"


### PR DESCRIPTION
Refs: #136 

## やったこと
- 書籍が登録されていないとき「書籍はまだありません」という文言（アイコンも）を表示するようにした
- 書籍一覧をテーブルたぐを使って記述した
- 「投稿日」や「読み返す日」など見出しをつけた
## 変更前
![image](https://user-images.githubusercontent.com/57053236/157447161-7ae6a162-718e-4101-8343-3c54c629b6b7.png)

## 変更後
書籍一覧をtableにした
「投稿日」や「読み返す日」など見出しをつけた
![image](https://user-images.githubusercontent.com/57053236/157445456-8f23c124-f6aa-4803-aa5b-d8678ee73b3f.png)

書籍が登録されていないときのブランクページを作った
![image](https://user-images.githubusercontent.com/57053236/157445843-86bd2e7e-5851-4506-aac9-b699a5ad5732.png)

## 備考
書籍一覧をテーブルタグを使ってレイアウトしたがスマホで見た時のことを考える必要があるとアドバイスいただいた。
テーブルっぽくdivタグで作ると良さそう🤔