### PR TITLE
写真投稿時にメモできるようにした

### DIFF
--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -17,6 +17,6 @@ class PhotosController < ApplicationController
   private
 
   def photo_params
-    params.fetch(:photo, {}).permit(:image)
+    params.fetch(:photo, {}).permit(:image, :note)
   end
 end

--- a/app/javascript/styles/_photo.sass
+++ b/app/javascript/styles/_photo.sass
@@ -18,3 +18,10 @@
 
 .blank-page
   margin: 100px 0
+
+.photo-section
+  .note
+    border-radius: 10px
+    border: 2px solid #ccc
+    width: 400px
+    overflow-wrap: normal

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -4,5 +4,6 @@ class Photo < ApplicationRecord
   include ImageUploader::Attachment(:image)
   belongs_to :book
 
+  validates :note, length: { maximum: 140 }
   validates :image, presence: { message: 'が選択されていません' }
 end

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -23,9 +23,12 @@
 div class="photo-index is-flex is-flex-wrap-wrap is-align-content-flex-start #{'is-justify-content-center' if @photos.blank?}"
   - if @photos.present?
     - @photos.each do |photo|
-      .photo-section.m-3
+      .photo-section.is-flex.is-flex-direction-column.m-3
         - if photo.image
           = image_tag photo.image[:medium].url, class: "image-#{photo.id}"
+        - if photo.note?
+          .note.p-2.my-2
+            = photo.note
   - else
     .blank-page.has-text-centered.has-text-grey
       .o-empty-message__text

--- a/app/views/photos/_form.html.slim
+++ b/app/views/photos/_form.html.slim
@@ -11,4 +11,8 @@
       = f.hidden_field :image, value: f.object.cached_image_data, id: 'photo-image'
       = f.file_field :image, class: 'file'
       #new-image.my-2
+  .field
+    .control
+      = f.label :note, class: 'label'
+      = f.text_area :note, class: 'textarea', placeholder: '(任意)'
   = f.submit '投稿する', class: 'button is-success'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,6 +9,7 @@ ja:
         title: 書籍名
       photo:
         image: 写真
+        note: メモ
         updated_at: 投稿日
       read_history:
         summary: サマリー

--- a/db/migrate/20220310062326_add_note_to_photos.rb
+++ b/db/migrate/20220310062326_add_note_to_photos.rb
@@ -1,0 +1,5 @@
+class AddNoteToPhotos < ActiveRecord::Migration[7.0]
+  def change
+    add_column :photos, :note, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,24 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_10_055416) do
-
+ActiveRecord::Schema[7.0].define(version: 2022_03_10_062326) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "books", force: :cascade do |t|
     t.string "title", null: false
     t.bigint "user_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_books_on_user_id"
   end
 
   create_table "photos", force: :cascade do |t|
     t.text "image_data", null: false
     t.bigint "book_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "note"
     t.index ["book_id"], name: "index_photos_on_book_id"
   end
 
@@ -36,8 +36,8 @@ ActiveRecord::Schema.define(version: 2022_02_10_055416) do
     t.text "description"
     t.date "read_back_at", null: false
     t.bigint "book_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["book_id"], name: "index_read_histories_on_book_id"
   end
 
@@ -45,8 +45,8 @@ ActiveRecord::Schema.define(version: 2022_02_10_055416) do
     t.string "provider", null: false
     t.string "uid", null: false
     t.string "image_url", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
   end
 

--- a/spec/factories/photos.rb
+++ b/spec/factories/photos.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
         'image/png'
       )
     end
+    note { 'メモの内容です' }
     association :book
 
     trait :within_file_size do

--- a/spec/models/photo_spec.rb
+++ b/spec/models/photo_spec.rb
@@ -35,4 +35,20 @@ RSpec.describe Photo, type: :model do
     photo.valid?
     expect(photo.errors[:image]).to include('が選択されていません')
   end
+
+  it 'メモが入力されていなくても有効なこと' do
+    photo = FactoryBot.build(:photo, note: nil)
+    expect(photo).to be_valid
+  end
+
+  it 'メモに140文字入力されている場合は有効な状態であること' do
+    photo = FactoryBot.build(:photo, note: 'a' * 140)
+    expect(photo).to be_valid
+  end
+
+  it 'メモに141文字以上入力されている場合は無効な状態であること' do
+    photo = FactoryBot.build(:photo, note: 'a' * 141)
+    photo.valid?
+    expect(photo.errors[:note]).to include('は140文字以内で入力してください')
+  end
 end


### PR DESCRIPTION
Refs: #116 

## 概要
noteカラムを追加し、写真を投稿するとき任意でメモできるようにした。

## やったこと
- カラムの追加
- バリデーションの設定
- DBに保存できるようにコントローラー、Viewの修正(form)
- モデルスペック、システムスペックの追加
- 作成したメモを表示できるようにした

## 変更後
![image](https://user-images.githubusercontent.com/57053236/157812784-5f35698c-9ad2-47cb-ad97-26292f146d28.png)
