### PR TITLE
書籍一覧画面で写真の投稿枚数を表示させるようにした

### DIFF
--- a/app/javascript/packs/application.sass
+++ b/app/javascript/packs/application.sass
@@ -2,5 +2,6 @@
 @import '../styles/_header'
 @import '../styles/_photo'
 @import '../styles/_read_history'
+@import '../styles/_book'
 @import '../styles/_0-variables.sass'
 @import '../styles/_1-modules.sass'

--- a/app/javascript/styles/_body.sass
+++ b/app/javascript/styles/_body.sass
@@ -5,6 +5,7 @@ body
   display: flex
   flex-direction: column
   background-color: #fff
-
+  a
+    color: #4ec2bb
 main
   flex: 1

--- a/app/javascript/styles/_book.sass
+++ b/app/javascript/styles/_book.sass
@@ -1,0 +1,6 @@
+span.photo-count
+  border: 2px solid #6a6a6a
+  padding: 1px 18px
+  border-radius: 14px
+  font-size: 20px
+  color: #6a6a6a

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -17,7 +17,10 @@ hr
     tbody
       - @books.each do |book|
         tr
-          td = link_to book.title, book_path(book)
+          td = link_to book_path(book), class: 'is-size-5' do
+            = book.title
+            span.photo-count.ml-4 = book.photos.count
+
           td = last_update_of_photo(book)
           td = l(book.read_histories.last.read_back_at, format: :date) if book.read_histories.present?
 - else

--- a/spec/system/photos_spec.rb
+++ b/spec/system/photos_spec.rb
@@ -24,7 +24,14 @@ RSpec.describe 'Photos', type: :system do
         sign_in_as user_a
         visit book_path(book)
 
-        have_content 'メモの内容です'
+        expect(page).to have_content 'メモの内容です'
+      end
+
+      it '投稿した写真の枚数が表示される' do
+        sign_in_as user_a
+        visit book_path(book)
+
+        expect(page).to have_selector '.photo-count', text: '1枚'
       end
     end
 


### PR DESCRIPTION
Refs: #152 
登録した書籍に何枚写真が投稿されているか分かるように表示させた。

## 変更前
![image](https://user-images.githubusercontent.com/57053236/158571258-187fe21f-0c67-4d30-833e-6c4904ca1cd4.png)


## 変更後
![image](https://user-images.githubusercontent.com/57053236/158571141-0682a1cb-2492-4dc3-a298-6c88cfb7c5ab.png)

## 備考
リンクの色をメインカラーに合わせた