### PR TITLE
写真詳細画面の作成

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -3,6 +3,7 @@
 class BooksController < ApplicationController
   before_action :set_book, only: %i[show edit update destroy]
   before_action :allow_only_book_pages_from_your_own_book, only: %i[show edit update destroy]
+
   def index
     @book = current_user.books.new
     @books = current_user.books.order(created_at: :desc).page(params[:page])

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -2,7 +2,7 @@
 
 class BooksController < ApplicationController
   before_action :set_book, only: %i[show edit update destroy]
-  before_action :allow_only_book_pages_from_your_own_book, only: %i[show edit update destroy]
+  before_action :correct_user, only: %i[show edit update destroy]
 
   def index
     @book = current_user.books.new
@@ -49,7 +49,7 @@ class BooksController < ApplicationController
     @book = Book.find(params[:id])
   end
 
-  def allow_only_book_pages_from_your_own_book
+  def correct_user
     return if current_user == @book.user
 
     redirect_to books_url

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -14,6 +14,19 @@ class PhotosController < ApplicationController
     end
   end
 
+  def show
+    @photo = Photo.find(params[:id])
+  end
+
+  def update
+    @photo = Photo.find(params[:id])
+    if @photo.update(photo_params)
+      redirect_to book_path(@photo.book)
+    else
+      render :show
+    end
+  end
+
   private
 
   def photo_params

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -38,7 +38,7 @@ class PhotosController < ApplicationController
   end
 
   def correct_user
-    return  if current_user == @photo.book.user
+    return if current_user == @photo.book.user
 
     redirect_to books_url
   end

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class PhotosController < ApplicationController
+  before_action :set_photo, only: %i[show update]
+  before_action :correct_user, only: %i[show update]
+
   def new
     @photo = Book.find(params[:book_id]).photos.new
   end
@@ -14,14 +17,11 @@ class PhotosController < ApplicationController
     end
   end
 
-  def show
-    @photo = Photo.find(params[:id])
-  end
+  def show; end
 
   def update
-    @photo = Photo.find(params[:id])
     if @photo.update(photo_params)
-      redirect_to book_path(@photo.book)
+      redirect_to book_path(@photo.book), notice: 'メモを更新しました'
     else
       render :show
     end
@@ -31,5 +31,15 @@ class PhotosController < ApplicationController
 
   def photo_params
     params.fetch(:photo, {}).permit(:image, :note)
+  end
+
+  def set_photo
+    @photo = Photo.find(params[:id])
+  end
+
+  def correct_user
+    return  if current_user == @photo.book.user
+
+    redirect_to books_url
   end
 end

--- a/app/javascript/styles/_photo.sass
+++ b/app/javascript/styles/_photo.sass
@@ -20,6 +20,8 @@
   margin: 100px 0
 
 .photo-section
+  img
+    width: 100%
   .note
     border-radius: 10px
     border: 2px solid #ccc

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -28,7 +28,8 @@ div class="photo-index is-flex is-flex-wrap-wrap is-align-content-flex-start #{'
     - @photos.each do |photo|
       .photo-section.is-flex.is-flex-direction-column.m-3
         - if photo.image
-          = image_tag photo.image[:medium].url, class: "image-#{photo.id}"
+          = link_to book_photo_path(photo.book, photo) do
+            = image_tag photo.image[:medium].url, class: "image-#{photo.id}"
         - if photo.note?
           .note.p-2.my-2
             = photo.note

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -5,7 +5,7 @@
     h1.title.is-3 = @book.title
     = link_to '編集', edit_book_path(@book), class: 'button is-small is-responsive'
   .div
-    = link_to new_book_photos_path(@book), class: 'button is-warning is-rounded' do
+    = link_to new_book_photo_path(@book), class: 'button is-warning is-rounded' do
       span.icon.mr-1
         i.fas.fa-camera
       = '写真投稿'
@@ -39,7 +39,7 @@ div class="photo-index is-flex is-flex-wrap-wrap is-align-content-flex-start #{'
       .is-size-1
         i.far.fa-sad-tear
       .div
-        = link_to new_book_photos_path(@book), class: 'button is-warning is-rounded' do
+        = link_to new_book_photo_path(@book), class: 'button is-warning is-rounded' do
           span.icon.mr-1
             i.fas.fa-camera
           = '写真投稿'

--- a/app/views/photos/show.html.slim
+++ b/app/views/photos/show.html.slim
@@ -1,0 +1,22 @@
+- content_for(:html_title) { "写真詳細(#{@photo.book.title})" }
+
+h1.title.is-3 写真の詳細画面
+
+.columns.is-flex
+  .column.is-7
+    - if @photo.image
+      = image_tag @photo.image[:large].url, class: "image-#{@photo.id}"
+  .column.is-5
+    = form_with(model: [@photo.book, @photo]) do |f|
+      - if @photo.errors.any?
+        #error_explanation.message.is-light
+          ul
+            - @photo.errors.full_messages.each do |message|
+              li.message-body = message
+      .field
+        .control
+          = f.label :note, class: 'label'
+          = f.text_area :note, class: 'textarea', placeholder: '(任意)'
+      = f.submit class: 'button is-warning'
+    .has-text-right
+      = link_to '戻る', book_path(@photo.book)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   resource :retirement
 
   resources :books, except: %i(new) do
-    resource :photos, only: %i(new create)
+    resources :photos, only: %i(new create)
     resource :read_histories, only: %i(new create)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   resource :retirement
 
   resources :books, except: %i(new) do
-    resources :photos, only: %i(new create)
+    resources :photos, only: %i(new create show update)
     resource :read_histories, only: %i(new create)
   end
 end

--- a/spec/system/photos_spec.rb
+++ b/spec/system/photos_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Photos', type: :system do
   describe '投稿機能' do
     before do
       sign_in_as user_a
-      visit new_book_photos_path(book)
+      visit new_book_photo_path(book)
     end
 
     context 'ファイルを選択したとき' do

--- a/spec/system/photos_spec.rb
+++ b/spec/system/photos_spec.rb
@@ -112,4 +112,31 @@ RSpec.describe 'Photos', type: :system do
       end
     end
   end
+
+  describe '編集機能' do
+    let!(:photo) { FactoryBot.create(:photo, note: 'メモの編集テスト', book: book) }
+
+    context '自分が投稿した写真のメモ' do
+      it '編集できる' do
+        sign_in_as user_a
+        visit book_photo_path(photo.book, photo)
+
+        expect do
+          fill_in 'メモ', with: 'メモを編集してみた'
+          click_on '更新する'
+
+          expect(page).to have_content 'メモを更新しました'
+          expect(page).to have_content 'メモを編集してみた'
+        end.to change(Photo, :count).by(0)
+      end
+
+      it '他のユーザは編集できない', js: true do
+        sign_in_as user_b
+        visit book_photo_path(photo.book, photo)
+
+        expect(page).not_to have_content 'メモの編集テスト'
+        expect(current_path).to eq books_path
+      end
+    end
+  end
 end


### PR DESCRIPTION
Refs: #142 

写真詳細画面を作成し、そのページでメモを編集できるようにした。
また、URL直接入力で他のユーザーがアクセスできないようにメソッドを追加した。

## 変更後
![image](https://user-images.githubusercontent.com/57053236/159104592-94429b94-9364-45a0-8ebc-c56791733f8e.png)
