### PR TITLE
不要と思われるcloudinaryの環境変数を削除した

### DIFF
--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -4,11 +4,6 @@ require "cloudinary"
 require "shrine/storage/cloudinary"
 
 if Rails.env.production?
-  Cloudinary.config(
-    cloud_name: Rails.application.credentials.cloudinary[:cloud_name],
-    api_key:    Rails.application.credentials.cloudinary[:api_key],
-    api_secret: Rails.application.credentials.cloudinary[:api_secret]
-  )
   Shrine.storages = {
   cache: Shrine::Storage::Cloudinary.new(prefix: "cache"),
   store: Shrine::Storage::Cloudinary.new(prefix: "reread")


### PR DESCRIPTION
Refs: #144 

メンターの方からCloudinaryは`CLOUDINARY_URL`という環境変数を見ているという情報を得たので`shrine.rb`に記述していたCloudinaryの環境変数は削除した。

本番環境でしか確認できないため、試してみてダメだったらもどに戻す。