### PR TITLE
写真詳細画面(メモ編集画面)をレスポンシブデザインに対応させた

### DIFF
--- a/app/javascript/styles/_body.sass
+++ b/app/javascript/styles/_body.sass
@@ -7,6 +7,8 @@ body
   background-color: #fff
   a
     color: #4ec2bb
+  h1
+    font-weight: bold
 main
   flex: 1
 

--- a/app/views/books/edit.html.slim
+++ b/app/views/books/edit.html.slim
@@ -1,6 +1,6 @@
 - content_for(:html_title) { '書籍名の編集' }
 
-h1.title.is-3 = @book.title
+h1.is-size-3.is-size-5-mobile = @book.title
 
 = render 'form', book: @book
 = link_to '戻る', book_path(@book)

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -2,8 +2,8 @@
 
 .book-info.is-flex.is-justify-content-space-between.is-align-items-center.py-2
   .book-title.is-flex.is-align-items-center
-    h1.title.is-3 = @book.title
-    = link_to '編集', edit_book_path(@book), class: 'button is-small is-responsive'
+    h1.is-size-3-tablet.is-size-5-mobile = @book.title
+    = link_to '編集', edit_book_path(@book), class: 'button is-small is-responsive ml-3'
   .div
     = link_to new_book_photo_path(@book), class: 'button is-warning is-rounded' do
       span.icon.mr-1

--- a/app/views/photos/show.html.slim
+++ b/app/views/photos/show.html.slim
@@ -1,9 +1,9 @@
 - content_for(:html_title) { "写真詳細(#{@photo.book.title})" }
 
-h1.title.is-3
+h1.is-size-3-tablet
   = "写真の詳細画面(#{@photo.book.title})"
 
-.columns.is-flex
+.columns
   .column.is-7
     - if @photo.image
       = image_tag @photo.image[:large].url, class: "image-#{@photo.id}"

--- a/app/views/photos/show.html.slim
+++ b/app/views/photos/show.html.slim
@@ -1,6 +1,6 @@
 - content_for(:html_title) { "写真詳細(#{@photo.book.title})" }
 
-h1.is-size-3-tablet
+h1.is-size-3-tablet.is-size-5-mobile
   = "写真の詳細画面(#{@photo.book.title})"
 
 .columns

--- a/app/views/read_histories/new.html.slim
+++ b/app/views/read_histories/new.html.slim
@@ -1,6 +1,6 @@
 - content_for(:html_title) { '再読日の設定' }
 
-h1.title.is-3 = "「#{@read_history.book.title}」を読み返す日の設定"
+h1.is-size-3-tablet.is-size-6-mobile = "「#{@read_history.book.title}」を読み返す日の設定"
 
 = render 'form', read_history: @read_history
 .div.has-text-right


### PR DESCRIPTION
Refs: #163 

## 概要
スマホでサイズの画面で見た時、写真の詳細とメモの編集フォームが横並びになって詰まっていたので、縦並びになるように変更した。また、スマホサイズの画面で見た時、h1タグの文字の大きさが大きくなりすぎて2行にわたって表示されてしまう問題をブレークポイントを設定して解決した。

## 変更前
![image](https://user-images.githubusercontent.com/57053236/160141903-85faac88-a4d8-4963-9021-d262838f683a.png)

## 変更後
![image](https://user-images.githubusercontent.com/57053236/160142010-8d9af701-c32d-4a22-bfa5-c9f1254477b2.png)
