### PR TITLE
Googleカレンダーの権限のスコープを変更した

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -2,7 +2,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   if Rails.env.development? || Rails.env.test?
     provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'],  ENV['GOOGLE_CLIENT_SECRET'],
     {
-      scope: 'userinfo.email, userinfo.profile, https://www.googleapis.com/auth/calendar',prompt: 'select_account'
+      scope: 'userinfo.email, userinfo.profile, https://www.googleapis.com/auth/calendar.events',prompt: 'select_account'
     }
 
   else
@@ -10,7 +10,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
       Rails.application.credentials.google[:client_id],
       Rails.application.credentials.google[:client_secret],
       {
-      scope: 'userinfo.email, userinfo.profile, https://www.googleapis.com/auth/calendar',prompt: 'select_account'
+      scope: 'userinfo.email, userinfo.profile, https://www.googleapis.com/auth/calendar.events',prompt: 'select_account'
       }
   end
 end


### PR DESCRIPTION
Google OAuth APIの利用申請のためGoogleカレンダーのスコープを狭めた