### PR TITLE
bin/setupにyarnを追加した

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -17,6 +17,9 @@ FileUtils.chdir APP_ROOT do
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
 
+  # Install JavaScript dependencies
+  system! 'bin/yarn'
+
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")
   #   FileUtils.cp "config/database.yml.sample", "config/database.yml"


### PR DESCRIPTION
- Refs: #67 

## 概要
bin/setupのファイルにyarnをインストールするコマンドが記述されていなかったため、bin/yarnを利用してyarnをインストールするこ記述を追加した。