### PR TITLE
[レビュー対応] dotenvをdevelopment, testグループに移動させた

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'dotenv-rails'
   gem 'factory_bot_rails'
   gem 'rspec-rails'
 end
@@ -58,7 +59,6 @@ group :test do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'dotenv-rails'
 gem 'google-api-client'
 gem 'google-apis-calendar_v3', '~> 0.15.0'
 gem 'html2slim'


### PR DESCRIPTION
- Refs: #183 

## 概要
doenvは開発環境やテスト環境でしか使用しないのでGemfile直下ではなく、development, testのグループの中に移動させた。