### PR TITLE
[レビュー対応]Rails7の設定を読み込むように変更した

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -8,4 +8,5 @@ class Book < ApplicationRecord
   paginates_per 10
 
   validates :title, length: { maximum: 50 }, presence: true
+  validates :user, presence: true
 end

--- a/app/models/read_history.rb
+++ b/app/models/read_history.rb
@@ -4,7 +4,7 @@ class ReadHistory < ApplicationRecord
   belongs_to :book
   validates :summary, length: { maximum: 50 }, presence: true
   validates :description, length: { maximum: 300 }
-  validates :read_back_at, presence: true
+  validates :read_back_at, :book, presence: true
   validate :date_to_read_back_should_be_after_today
 
   private

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,8 +20,6 @@ Bundler.require(*Rails.groups)
 
 module Reread
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.1
     config.time_zone = 'Tokyo'
     config.i18n.default_locale = :ja
     config.generators do |g|

--- a/spec/system/books_spec.rb
+++ b/spec/system/books_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Books', type: :system do
       it '登録される' do
         sign_in_as user_a
         expect do
-          fill_in '書籍名', with: '最初の書籍'
+          fill_in 'book[title]', with: '最初の書籍'
           click_button '登録する'
         end.to change(user_a.books, :count).by(1)
 
@@ -43,7 +43,7 @@ RSpec.describe 'Books', type: :system do
       it 'エラーになる' do
         sign_in_as user_a
         expect do
-          fill_in '書籍名', with: ''
+          fill_in 'book[title]', with: ''
           click_button '登録する'
         end.to change(user_a.books, :count).by(0)
 
@@ -113,7 +113,7 @@ RSpec.describe 'Books', type: :system do
         visit edit_book_path(book)
 
         expect do
-          fill_in '書籍名', with: '変更した書籍'
+          fill_in 'book[title]', with: '変更した書籍'
           click_button '更新する'
         end.to change(user_a.books, :count).by(0)
 
@@ -126,7 +126,7 @@ RSpec.describe 'Books', type: :system do
         visit edit_book_path(book)
 
         expect do
-          fill_in '書籍名', with: ''
+          fill_in 'book[title]', with: ''
           click_button '更新する'
         end.to change(user_a.books, :count).by(0)
 

--- a/spec/system/photos_spec.rb
+++ b/spec/system/photos_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe 'Photos', type: :system do
     context 'ファイルを選択したとき' do
       it '投稿できる' do
         expect do
-          attach_file '写真', "#{Rails.root}/spec/factories/test_640x320.png"
-          fill_in 'メモ', with: 'これはメモです'
+          attach_file 'photo[image]', "#{Rails.root}/spec/factories/test_640x320.png"
+          fill_in 'photo[note]', with: 'これはメモです'
           click_on '投稿する'
         end.to change(book.photos, :count).by(1)
 
@@ -75,7 +75,7 @@ RSpec.describe 'Photos', type: :system do
     context 'ファイルを選択しなかったとき' do
       it 'エラーになる' do
         expect do
-          fill_in 'メモ', with: 'これはメモです'
+          fill_in 'photo[note]', with: 'これはメモです'
           click_on '投稿する'
         end.to change(book.photos, :count).by(0)
 
@@ -88,8 +88,8 @@ RSpec.describe 'Photos', type: :system do
     context 'メモを入力したとき' do
       it '投稿できる' do
         expect do
-          attach_file '写真', "#{Rails.root}/spec/factories/test_640x320.png"
-          fill_in 'メモ', with: 'これはメモです'
+          attach_file 'photo[image]', "#{Rails.root}/spec/factories/test_640x320.png"
+          fill_in 'photo[note]', with: 'これはメモです'
           click_on '投稿する'
         end.to change(book.photos, :count).by(1)
 
@@ -101,8 +101,8 @@ RSpec.describe 'Photos', type: :system do
     context 'メモに140字より多い文字数を入力したとき' do
       it '投稿できない' do
         expect do
-          attach_file '写真', "#{Rails.root}/spec/factories/test_640x320.png"
-          fill_in 'メモ', with: 'a' * 141
+          attach_file 'photo[image]', "#{Rails.root}/spec/factories/test_640x320.png"
+          fill_in 'photo[note]', with: 'a' * 141
           click_on '投稿する'
         end.to change(book.photos, :count).by(0)
 
@@ -122,7 +122,7 @@ RSpec.describe 'Photos', type: :system do
         visit book_photo_path(photo.book, photo)
 
         expect do
-          fill_in 'メモ', with: 'メモを編集してみた'
+          fill_in 'photo[note]', with: 'メモを編集してみた'
           click_on '更新する'
 
           expect(page).to have_content 'メモを更新しました'


### PR DESCRIPTION
- Refs: #185 

## 概要
Railsをアップグレードした差異、`config/application.rb`にある`config.load_defaults`が残っていたためRails6.1の設定を読み込んでしまっていた。そのため、Rails7の設定を読み込むように変更した。

また、Rails7にしたことで一部テストが落ちたため修正した。