### PR TITLE
ファイルを選択したときプレビュー画面が表示されないバグを修正した

### DIFF
--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -8,7 +8,6 @@ if (document.URL.match(/new/)) {
 
       imageElement.appendChild(blobImage)
     }
-
     document.getElementById('photo_image').addEventListener('change', (e) => {
       const imageContent = document.querySelector('img')
       if (imageContent) imageContent.remove()

--- a/app/views/photos/_form.html.slim
+++ b/app/views/photos/_form.html.slim
@@ -9,7 +9,7 @@
       = f.label :image, class: 'file-label'
       = image_tag f.object.image_url if f.object.cached_image_data
       = f.hidden_field :image, value: f.object.cached_image_data, id: 'photo-image'
-      = f.file_field :image, class: 'file'
+      = f.file_field :image, class: 'file', id: 'photo_image'
       #new-image.my-2
   .field
     .control

--- a/spec/system/photos_spec.rb
+++ b/spec/system/photos_spec.rb
@@ -43,6 +43,15 @@ RSpec.describe 'Photos', type: :system do
     end
 
     context 'ファイルを選択したとき' do
+      it 'プレビュー画像が表示される', js: true do
+        expect(page).not_to have_selector 'img.new-img'
+
+        expect do
+          attach_file 'photo[image]', "#{Rails.root}/spec/factories/test_640x320.png"
+          expect(page).to have_selector 'img.new-img'
+        end.to change(book.photos, :count).by(0)
+      end
+
       it '投稿できる' do
         expect do
           attach_file 'photo[image]', "#{Rails.root}/spec/factories/test_640x320.png"


### PR DESCRIPTION
- Refs: #190 

## 概要
document.getElementByIdで要素をうまく取得できていなかったためプレビュー画面が表示されなかった。
プレビュー画面が表示されるかどうかのテストを追加した。