### PR TITLE
Googleカレンダーに設定できないバグを解消した

### DIFF
--- a/app/models/calendar_client.rb
+++ b/app/models/calendar_client.rb
@@ -11,7 +11,7 @@ class CalendarClient
       token_credential_uri: 'https://accounts.google.com/o/oauth2/token',
       access_token: Rails.cache.read(user.uid),
       refresh_token: Rails.cache.read(user.uid + user.id.to_s),
-      expires_at: Rails.cache.read(user.uid + 'expires_at')
+      expires_at: Rails.cache.read("#{user.uid}expires_at")
     )
   end
 
@@ -41,7 +41,7 @@ class CalendarClient
     return unless @client.expired?
 
     @client.refresh!
-    Rails.cache.write(@user.uid + 'expires_at', @client.expires_at)
+    Rails.cache.write("#{@user.uid}expires_at", @client.expires_at)
     Rails.cache.fetch(@user.uid, expires_in: @client.expires_at) do
       @client.access_token
     end

--- a/app/models/calendar_client.rb
+++ b/app/models/calendar_client.rb
@@ -11,7 +11,7 @@ class CalendarClient
       token_credential_uri: 'https://accounts.google.com/o/oauth2/token',
       access_token: Rails.cache.read(user.uid),
       refresh_token: Rails.cache.read(user.uid + user.id.to_s),
-      expires_at: Rails.cache.read('expires_at')
+      expires_at: Rails.cache.read(user.uid + 'expires_at')
     )
   end
 
@@ -41,6 +41,7 @@ class CalendarClient
     return unless @client.expired?
 
     @client.refresh!
+    Rails.cache.write(@user.uid + 'expires_at', @client.expires_at)
     Rails.cache.fetch(@user.uid, expires_in: @client.expires_at) do
       @client.access_token
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
 
   def store_credentials_in_cache(auth_hash)
     expires_at = auth_hash.credentials.expires_at
-    Rails.cache.write('expires_at', expires_at)
+    Rails.cache.write(uid + 'expires_at', expires_at)
     Rails.cache.fetch(uid, expires_in: expires_at) do
       auth_hash.credentials.token
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
 
   def store_credentials_in_cache(auth_hash)
     expires_at = auth_hash.credentials.expires_at
-    Rails.cache.write(uid + 'expires_at', expires_at)
+    Rails.cache.write("#{uid}expires_at", expires_at)
     Rails.cache.fetch(uid, expires_in: expires_at) do
       auth_hash.credentials.token
     end


### PR DESCRIPTION
- Refs: #199 
- Refs: #153

## 概要
ユーザーがログインする際、アクセストークンの有効期限をキャッシュに保存していたが、`Rails.cache.write('expires_at', hoge)`という形になっており、ユーザーごとに一意なkeyでなかったため、ユーザーがログインするたびに上書きされている状態になっていた。

そこでユーザー毎に一意なkeyになるように設定した。

また、アクセストークンの有効期限が過ぎていた場合キャッシュされている有効期限の更新がされていなかったため、長時間ログインしていて、Googleカレンダーに設定しようとするとAPIが叩けない状態になっていたので解消した。

多分修正できていると思う。