### PR TITLE
アクセストークンのリフレッシュ後新しいアクセストークンがキャッシュに保存されない不具合を解消した

### DIFF
--- a/app/models/calendar_client.rb
+++ b/app/models/calendar_client.rb
@@ -7,7 +7,6 @@ class CalendarClient
     @client = Signet::OAuth2::Client.new(
       client_id: ENV['GOOGLE_CLIENT_ID'],
       client_secret: ENV['GOOGLE_CLIENT_SECRET'],
-      auth_url: 'https://accounts.google.com/o/oauth2/auth',
       token_credential_uri: 'https://accounts.google.com/o/oauth2/token',
       access_token: Rails.cache.read(user.uid),
       refresh_token: Rails.cache.read(user.uid + user.id.to_s),

--- a/app/models/calendar_client.rb
+++ b/app/models/calendar_client.rb
@@ -7,6 +7,7 @@ class CalendarClient
     @client = Signet::OAuth2::Client.new(
       client_id: ENV['GOOGLE_CLIENT_ID'],
       client_secret: ENV['GOOGLE_CLIENT_SECRET'],
+      authorization_uri: 'https://accounts.google.com/o/oauth2/auth',
       token_credential_uri: 'https://accounts.google.com/o/oauth2/token',
       access_token: Rails.cache.read(user.uid),
       refresh_token: Rails.cache.read(user.uid + user.id.to_s),
@@ -41,8 +42,6 @@ class CalendarClient
 
     @client.refresh!
     Rails.cache.write("#{@user.uid}expires_at", @client.expires_at)
-    Rails.cache.fetch(@user.uid, expires_in: @client.expires_at) do
-      @client.access_token
-    end
+    Rails.cache.write(@user.uid, @client.access_token)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,9 +16,7 @@ class User < ApplicationRecord
   def store_credentials_in_cache(auth_hash)
     expires_at = auth_hash.credentials.expires_at
     Rails.cache.write("#{uid}expires_at", expires_at)
-    Rails.cache.fetch(uid, expires_in: expires_at) do
-      auth_hash.credentials.token
-    end
+    Rails.cache.write(uid, auth_hash.credentials.token)
     Rails.cache.write(uid + id.to_s, auth_hash.credentials.refresh_token)
   end
 end


### PR DESCRIPTION
- Refs: #201 

## 概要
アクセストークンのリフレッシュ後Rails.cache.fetchで新しいアクセストークンを保存していたが、どうも更新されていないようだったのでリフレッシュ後にAPIを叩いた時にエラーが起きていた。そのため、リフレッシュ後に新しいアクセストークンをキャッシュに保存するように修正した。