### PR TITLE
本番環境でMemcachedを使うよう設定した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,3 +73,4 @@ gem 'shrine'
 gem 'shrine-cloudinary'
 gem 'slim-rails'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'dalli'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
     concurrent-ruby (1.1.9)
     content_disposition (1.0.0)
     crass (1.0.6)
+    dalli (3.2.1)
     declarative (0.0.20)
     diff-lcs (1.5.0)
     digest (3.1.0)
@@ -479,6 +480,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   capybara!
+  dalli
   dotenv-rails
   factory_bot_rails
   google-api-client

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,15 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :mem_cache_store,
+    (ENV["MEMCACHIER_SERVERS"] || "").split(","),
+    {:username => ENV["MEMCACHIER_USERNAME"],
+    :password => ENV["MEMCACHIER_PASSWORD"],
+    :failover => true,
+    :socket_timeout => 1.5,
+    :socket_failure_delay => 0.2,
+    :down_retry_delay => 60
+    }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
- Refs: #199 
- Refs: #201 

## 概要
現在はログインしたときのアクセストークンはキャッシュに保存している。
が、herokuでは1日一回サーバーが再起動になってキャッシュのデータが消えてしまうので本番環境はmemcachedを使うように設定した。