### PR TITLE
本番環境のキャッシュストアをMemcachedからRedisに変更した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,4 +73,4 @@ gem 'shrine'
 gem 'shrine-cloudinary'
 gem 'slim-rails'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
-gem 'dalli'
+gem 'redis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,6 @@ GEM
     concurrent-ruby (1.1.9)
     content_disposition (1.0.0)
     crass (1.0.6)
-    dalli (3.2.1)
     declarative (0.0.20)
     diff-lcs (1.5.0)
     digest (3.1.0)
@@ -334,6 +333,7 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.6.0)
     regexp_parser (2.2.1)
     representable (3.1.1)
       declarative (< 0.1.0)
@@ -480,7 +480,6 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   capybara!
-  dalli
   dotenv-rails
   factory_bot_rails
   google-api-client
@@ -501,6 +500,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 7.0.2)
   rails-i18n
+  redis
   rspec-rails
   rubocop-fjord
   rubocop-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,15 +51,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  config.cache_store = :mem_cache_store,
-    (ENV["MEMCACHIER_SERVERS"] || "").split(","),
-    {:username => ENV["MEMCACHIER_USERNAME"],
-    :password => ENV["MEMCACHIER_PASSWORD"],
-    :failover => true,
-    :socket_timeout => 1.5,
-    :socket_failure_delay => 0.2,
-    :down_retry_delay => 60
-    }
+  config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
- Refs: #199 


## 概要
Memcachedを使ってアクセストークンを保存していたが、サーバーが再起動するタイミングでキャッシュ情報が失われているみたいなので、Redisに変更してみることにした。サーバーが再起動してもPAIが叩けるかは検証する必要がある。
