### PR TITLE
ファイル選択時にヘッダーのロゴが消えてしまう問題を解消した

### DIFF
--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -1,4 +1,4 @@
-if (document.URL.match(/new/)) {
+if (document.URL.match(/books\/\d+\/photos\/new/)) {
   document.addEventListener('DOMContentLoaded', () => {
     const createImageHTML = (blob) => {
       const imageElement = document.getElementById('new-image')
@@ -9,7 +9,8 @@ if (document.URL.match(/new/)) {
       imageElement.appendChild(blobImage)
     }
     document.getElementById('photo_image').addEventListener('change', (e) => {
-      const imageContent = document.querySelector('img')
+      const imageContent = document.querySelector('.new-img')
+      console.log(imageContent)
       if (imageContent) imageContent.remove()
 
       const file = e.target.files[0]


### PR DESCRIPTION
- Refs: #208 

## 変更後
![image](https://user-images.githubusercontent.com/57053236/162894862-05bb7b58-07ba-4b99-abe4-3a69575f5efb.png)

## 原因
あるファイルをアタッチした後、別のファイルをアタッチした時にプレビュー画像を削除するコードが走っていたが、`query_selector('img')`となっていたため、最初のimgタグであるロゴが取得され消えていた。