### PR TITLE
書籍一覧画面の横幅に制限を持たせた

### DIFF
--- a/app/javascript/styles/_book.sass
+++ b/app/javascript/styles/_book.sass
@@ -1,6 +1,10 @@
-span.photo-count
-  border: 2px solid #6a6a6a
-  padding: 1px 18px
-  border-radius: 14px
-  font-size: 20px
-  color: #6a6a6a
+.index-book
+  max-width: 1024px
+  margin: 0 auto
+
+  span.photo-count
+    border: 2px solid #6a6a6a
+    padding: 1px 18px
+    border-radius: 14px
+    font-size: 20px
+    color: #6a6a6a

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -1,31 +1,32 @@
 - content_for(:html_title) { '書籍の一覧' }
 
-h1.title.is-3 書籍の一覧
+.index-book.pt-4
+  h1.title.is-3 書籍の一覧
 
-= render 'form', book: @book
+  = render 'form', book: @book
 
-hr
-.mb-3
-  = paginate @books
-- if @books.present?
-  table.table.is-fullwidth
-    thead
-      tr
-        th = Book.human_attribute_name(:title)
-        th = Photo.human_attribute_name(:updated_at)
-        th = ReadHistory.human_attribute_name(:read_back_at)
-    tbody
-      - @books.each do |book|
+  hr
+  .mb-3
+    = paginate @books
+  - if @books.present?
+    table.table.is-fullwidth
+      thead
         tr
-          td = link_to book_path(book), class: 'is-size-5' do
-            = book.title
-            span.photo-count.ml-4 = book.photos.count
+          th = Book.human_attribute_name(:title)
+          th = Photo.human_attribute_name(:updated_at)
+          th = ReadHistory.human_attribute_name(:read_back_at)
+      tbody
+        - @books.each do |book|
+          tr
+            td = link_to book_path(book), class: 'is-size-5' do
+              = book.title
+              span.photo-count.ml-4 = book.photos.count
 
-          td = last_update_of_photo(book)
-          td = l(book.read_histories.last.read_back_at, format: :date) if book.read_histories.present?
-- else
-  .blank-page.has-text-centered.has-text-grey
-      .o-empty-message__text
-        | 書籍はまだありません
-      .is-size-1
-        i.far.fa-sad-tear
+            td = last_update_of_photo(book)
+            td = l(book.read_histories.last.read_back_at, format: :date) if book.read_histories.present?
+  - else
+    .blank-page.has-text-centered.has-text-grey
+        .o-empty-message__text
+          | 書籍はまだありません
+        .is-size-1
+          i.far.fa-sad-tear


### PR DESCRIPTION
- Refs: #206 

## 概要
max_widthを設定して1024pxより大きくならないようにした
コンテンツを中央よせになるようにした。

## 変更後
![image](https://user-images.githubusercontent.com/57053236/162988543-a6616e83-e1d3-45a6-a329-5c579629dc01.png)

