### PR TITLE
書籍一覧画面に常に表示されていた登録フォームをモーダルで表示するようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,8 @@ gem 'puma', '~> 5.0'
 # Use SCSS for stylesheets
 gem 'sass-rails', '>= 6'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
-gem 'webpacker', '~> 5.0'
 gem 'turbolinks', '~> 5'
+gem 'webpacker', '~> 5.0'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.7'

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'puma', '~> 5.0'
 gem 'sass-rails', '>= 6'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker', '~> 5.0'
+gem 'turbolinks', '~> 5'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -443,6 +443,9 @@ GEM
     tilt (2.0.10)
     timeout (0.2.0)
     trailblazer-option (0.1.2)
+    turbolinks (5.2.1)
+      turbolinks-source (~> 5.2)
+    turbolinks-source (5.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
@@ -512,6 +515,7 @@ DEPENDENCIES
   slim-rails
   slim_lint
   spring
+  turbolinks (~> 5)
   tzinfo-data
   web-console (>= 4.1.0)
   webdrivers

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,7 @@ import Turbolinks from 'turbolinks'
 import * as ActiveStorage from '@rails/activestorage'
 
 require('../src/header')
+require('../src/modal')
 require('./preview')
 
 Rails.start()

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,10 +4,12 @@
 // that code so it'll be compiled.
 
 import Rails from '@rails/ujs'
+import Turbolinks from 'turbolinks'
 import * as ActiveStorage from '@rails/activestorage'
 
 require('../src/header')
 require('./preview')
 
 Rails.start()
+Turbolinks.start()
 ActiveStorage.start()

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -1,5 +1,5 @@
 if (document.URL.match(/books\/\d+\/photos\/new/)) {
-  document.addEventListener('DOMContentLoaded', () => {
+  document.addEventListener('turbolinks:load', () => {
     const createImageHTML = (blob) => {
       const imageElement = document.getElementById('new-image')
       const blobImage = document.createElement('img')

--- a/app/javascript/src/header.js
+++ b/app/javascript/src/header.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('turbolinks:load', () => {
   const $navbarBurgers = Array.prototype.slice.call(
     document.querySelectorAll('.navbar-burger'),
     0

--- a/app/javascript/src/modal.js
+++ b/app/javascript/src/modal.js
@@ -1,0 +1,33 @@
+if (document.URL.match(/books\/?$/)) {
+  document.addEventListener('turbolinks:load', () => {
+    const $show = document.getElementById('show-modal')
+
+    $show.addEventListener('click', () => {
+      const $modal = document.getElementById('modal-window')
+      $modal.classList.add('is-active')
+
+    })
+
+    const $close = document.getElementById('close-modal')
+
+    $close.addEventListener('click', () => {
+      const $modal = document.getElementById('modal-window')
+      $modal.classList.remove('is-active')
+    })
+
+    const $background = document.getElementById('modal-background')
+
+    $background.addEventListener('click', () => {
+      const $modal = document.getElementById('modal-window')
+      $modal.classList.remove('is-active')
+    })
+
+    const $closeButton = document.getElementById('close-button')
+
+    $closeButton.addEventListener('click', () => {
+      const $modal = document.getElementById('modal-window')
+      $modal.classList.remove('is-active')
+    })
+
+  })
+}

--- a/app/javascript/src/modal.js
+++ b/app/javascript/src/modal.js
@@ -5,7 +5,6 @@ if (document.URL.match(/books\/?$/)) {
     $show.addEventListener('click', () => {
       const $modal = document.getElementById('modal-window')
       $modal.classList.add('is-active')
-
     })
 
     const $close = document.getElementById('close-modal')
@@ -28,6 +27,5 @@ if (document.URL.match(/books\/?$/)) {
       const $modal = document.getElementById('modal-window')
       $modal.classList.remove('is-active')
     })
-
   })
 }

--- a/app/javascript/styles/_book.sass
+++ b/app/javascript/styles/_book.sass
@@ -2,6 +2,10 @@
   max-width: 1024px
   margin: 0 auto
 
+  .columns
+    h1.column
+      width: 70%
+      margin: 0
   span.photo-count
     border: 2px solid #6a6a6a
     padding: 1px 18px

--- a/app/javascript/styles/_footer.sass
+++ b/app/javascript/styles/_footer.sass
@@ -1,6 +1,6 @@
 @charset 'UTF-8'
 
-footer
+footer.footer
   height: 140px
   a
     color: #7a7a7a

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -1,7 +1,7 @@
 - content_for(:html_title) { '書籍の一覧' }
 
 .index-book.pt-4
-  .columns.is-vcentered
+  .columns.is-vcentered.py-4
     h1.title.column.is-3 読み返したい本リスト
     #show-modal.column.has-text-right
       button.button.is-warning 読み返す本を登録する
@@ -27,8 +27,6 @@
           a#close-button.button = 'キャンセル'
           = f.submit class: 'button is-warning'
 
-
-  hr
   .mb-3
     = paginate @books
   - if @books.present?

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -3,15 +3,15 @@
 .index-book.pt-4
   h1.title.is-3 書籍の一覧
   #show-modal
-    button 読み返す本を登録する
+    button.button.is-warning 読み返す本を登録する
 
-  .modal.is-active
-    .modal-background
+  #modal-window.modal
+    #modal-background.modal-background
     .modal-card
       .modal-card-head
         p.modal-card-title
           | 読み返す本を登録する
-        button.delete aria-label="close"
+        button#close-modal.delete aria-label="close"
       = form_with model: @book, remote: true do |f|
         section.modal-card-body
           .content
@@ -23,7 +23,7 @@
             = f.label :title, class: 'label'
             = f.text_field :title, class: 'input'
         footer.modal-card-foot.is-justify-content-flex-end
-          a.button = 'キャンセル'
+          a#close-button.button = 'キャンセル'
           = f.submit class: 'button is-warning'
 
 

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -2,8 +2,30 @@
 
 .index-book.pt-4
   h1.title.is-3 書籍の一覧
+  #show-modal
+    button 読み返す本を登録する
 
-  = render 'form', book: @book
+  .modal.is-active
+    .modal-background
+    .modal-card
+      .modal-card-head
+        p.modal-card-title
+          | 読み返す本を登録する
+        button.delete aria-label="close"
+      = form_with model: @book, remote: true do |f|
+        section.modal-card-body
+          .content
+            - if @book.errors.any?
+              #error_explanation.message.is-light
+                ul
+                  - @book.errors.full_messages.each do |message|
+                    li.message-body = message
+            = f.label :title, class: 'label'
+            = f.text_field :title, class: 'input'
+        footer.modal-card-foot.is-justify-content-flex-end
+          a.button = 'キャンセル'
+          = f.submit class: 'button is-warning'
+
 
   hr
   .mb-3

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -1,9 +1,10 @@
 - content_for(:html_title) { '書籍の一覧' }
 
 .index-book.pt-4
-  h1.title.is-3 書籍の一覧
-  #show-modal
-    button.button.is-warning 読み返す本を登録する
+  .columns.is-vcentered
+    h1.title.column.is-3 読み返したい本リスト
+    #show-modal.column.has-text-right
+      button.button.is-warning 読み返す本を登録する
 
   #modal-window.modal
     #modal-background.modal-background

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,8 +9,8 @@ html
     = csrf_meta_tags
     = csp_meta_tag
     = favicon_link_tag('/favicon.ico')
-    = stylesheet_pack_tag 'application', media: 'all'
-    = javascript_pack_tag 'application'
+    = stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
     meta[name="google-site-verification" content="QYfOertXvzw7TxkAk8ZuV4mHEvDYBqxSQx-HJuym034"]
   body
     - unless current_page?(root_path)

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Users', type: :system do
       it 'ログインできる' do
         sign_in_as user
         expect(page).to have_content 'ログインしました'
-        expect(page).to have_content '書籍の一覧'
+        expect(page).to have_content '読み返したい本リスト'
       end
     end
 


### PR DESCRIPTION
- Refs: #212 

## 概要
書籍一覧画面の上部にあった、書籍登録のフォームは常にあると目障りなのでモーダルにして表示・非表示を切り替えられるようにした。

## 変更後
![image](https://user-images.githubusercontent.com/57053236/163321895-67e52be1-eca3-4cd7-9f57-9aa33838302e.png)

![image](https://user-images.githubusercontent.com/57053236/163321935-06dcf63c-1caf-4aa3-9c0a-b351e2e2a087.png)

## 備考
空文字を入力したときはバリデーションエラーに引っかかるが、登録ボタンを押すとモーダルウィンドウがinactiveになってしまい、バリデーションエラーが見えなくなっている（もう一度モーダルをactiveにするとバリデーションエラーは見える）。

この問題は別Issueで解決することにする。