### PR TITLE
書籍一覧ページUIを変更した。

### DIFF
--- a/app/javascript/styles/_0-variables.sass
+++ b/app/javascript/styles/_0-variables.sass
@@ -6,3 +6,6 @@
 $primary: #4ec2bb
 $info: #56BBF1
 $warning: #FFE162
+$link: #297671
+
+$table-cell-padding: 1em 0.75em

--- a/app/javascript/styles/_body.sass
+++ b/app/javascript/styles/_body.sass
@@ -5,8 +5,6 @@ body
   display: flex
   flex-direction: column
   background-color: #fff
-  a
-    color: #4ec2bb
   h1
     font-weight: bold
 main

--- a/app/javascript/styles/_book.sass
+++ b/app/javascript/styles/_book.sass
@@ -1,14 +1,19 @@
 .index-book
   max-width: 1024px
-  margin: 0 auto
-
+  table
+    td
+      vertical-align: baseline
+      a:hover
+        text-decoration-line: underline
+      a
+        span.photo-count
+          border: 1px solid #eee
+          padding: 1px 12px
+          border-radius: 15px
+          font-size: 20px
+          color: #808080
+          background-color: #eee
   .columns
     h1.column
       width: 70%
       margin: 0
-  span.photo-count
-    border: 2px solid #6a6a6a
-    padding: 1px 18px
-    border-radius: 14px
-    font-size: 20px
-    color: #6a6a6a

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -39,12 +39,12 @@
       tbody
         - @books.each do |book|
           tr
-            td = link_to book_path(book), class: 'is-size-5' do
+            td = link_to book_path(book), class: 'is-size-5 has-text-weight-semibold' do
               = book.title
-              span.photo-count.ml-4 = book.photos.count
+              span.photo-count.is-size-6.ml-4 = book.photos.count
 
-            td = last_update_of_photo(book)
-            td = l(book.read_histories.last.read_back_at, format: :date) if book.read_histories.present?
+            td.has-text-grey = last_update_of_photo(book)
+            td.has-text-grey = l(book.read_histories.last.read_back_at, format: :date) if book.read_histories.present?
   - else
     .blank-page.has-text-centered.has-text-grey
         .o-empty-message__text


### PR DESCRIPTION
- Refs: #215 

## やったこと
- 書籍の文字色をコントラスト比が高くなるように変更
- 文字の大きさ、太さを変更した
- 書籍一覧の全体を左寄せにした
- 写真の枚数やその他の情報の色、大きさを変更した書籍名が目立つようにした
- 書籍をhoberした時下線が出るようにした。
- tableのtrに余白を持たせた
## 変更後
![image](https://user-images.githubusercontent.com/57053236/163410240-51fa4616-d306-4bd3-8090-e75582cccf23.png)
