### PR TITLE
ボタンの形を統一した

### DIFF
--- a/app/javascript/styles/_photo.sass
+++ b/app/javascript/styles/_photo.sass
@@ -27,3 +27,11 @@
     border: 2px solid #ccc
     width: 400px
     overflow-wrap: normal
+
+div.photo-post-button-section
+  margin-top: 30px
+  margin-bottom: 30px
+  .button
+    width: 70px
+    height: 70px
+    border-radius: 50%

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -5,7 +5,7 @@
     h1.is-size-3-tablet.is-size-5-mobile = @book.title
     = link_to '編集', edit_book_path(@book), class: 'button is-small is-responsive ml-3'
   .div
-    = link_to new_book_photo_path(@book), class: 'button is-warning is-rounded' do
+    = link_to new_book_photo_path(@book), class: 'button is-warning' do
       span.icon.mr-1
         i.fas.fa-camera
       = '写真投稿'
@@ -18,7 +18,7 @@
   .photo-count
     p = "写真の枚数: #{@photos.count}枚"
   .google-button.has-text-right
-    = link_to new_book_read_histories_path(@book), class: 'button is-info is-rounded' do
+    = link_to new_book_read_histories_path(@book), class: 'button is-info' do
       span.icon.mr-1
         i.fas.fa-calendar-alt
       = 'Googleカレンダーに読み返す日を設定する'
@@ -40,7 +40,7 @@ div class="photo-index is-flex is-flex-wrap-wrap is-align-content-flex-start #{'
       .is-size-1
         i.far.fa-sad-tear
       .div
-        = link_to new_book_photo_path(@book), class: 'button is-warning is-rounded' do
+        = link_to new_book_photo_path(@book), class: 'button is-warning' do
           span.icon.mr-1
             i.fas.fa-camera
           = '写真投稿'

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -1,14 +1,9 @@
 - content_for(:html_title) { "投稿した写真(#{@book.title})" }
 
-.book-info.is-flex.is-justify-content-space-between.is-align-items-center.py-2
+.book-info.py-2
   .book-title.is-flex.is-align-items-center
     h1.is-size-3-tablet.is-size-5-mobile = @book.title
     = link_to '編集', edit_book_path(@book), class: 'button is-small is-responsive ml-3'
-  .div
-    = link_to new_book_photo_path(@book), class: 'button is-warning' do
-      span.icon.mr-1
-        i.fas.fa-camera
-      = '写真投稿'
 
 .photo-info.is-flex.is-justify-content-space-between.is-align-items-center.py-2
   -  if @photos.present?
@@ -49,3 +44,8 @@ div class="photo-index is-flex is-flex-wrap-wrap is-align-content-flex-start #{'
   = link_to 'この書籍を削除する', book_path(@book), method: :delete,
       data: { confirm: '投稿した写真も削除されます。よろしいですか？' }, class: 'button is-small'
   = link_to '戻る', books_path
+
+div.photo-post-button-section.has-text-right
+  = link_to new_book_photo_path(@book), class: 'button is-warning' do
+    span.icon
+      i.fa.fa-plus.is-size-3

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -45,7 +45,7 @@ div class="photo-index is-flex is-flex-wrap-wrap is-align-content-flex-start #{'
       data: { confirm: '投稿した写真も削除されます。よろしいですか？' }, class: 'button is-small'
   = link_to '戻る', books_path
 
-div.photo-post-button-section.has-text-right
+.photo-post-button-section.has-text-right
   = link_to new_book_photo_path(@book), class: 'button is-warning' do
     span.icon
       i.fa.fa-plus.is-size-3


### PR DESCRIPTION
- Refs: #220 

## 概要
丸型のボタンと四角のボタンが混在していたため四角のボタンに統一した。
また、写真投稿ボタンに関しては他と差別化したかったため、丸型の`+`のボタンにした。(す少しボタン大きすぎるかも）

![image](https://user-images.githubusercontent.com/57053236/163547246-5f7ad4a6-81a1-4557-be53-d8c0e491e441.png)


なお、全体の大きさの調整などは写真一覧画面のデザイン変更で行う。