### PR TITLE
写真投稿ボタンの位置を画面の右下に固定した

### DIFF
--- a/app/javascript/styles/_photo.sass
+++ b/app/javascript/styles/_photo.sass
@@ -29,15 +29,15 @@
     margin: 100px 0
 
 div.photo-post-button-section
-  margin-top: 30px
-  margin-bottom: 30px
-  // position: fixed
-  // top: 130px
-  // right: 20px
   .button
-    width: 70px
-    height: 70px
-    border-radius: 50%
+    width:180px
+    height: 50px
+    border-radius: 10px
+    position: fixed
+    bottom: 40px
+    right: 40px
+    p
+      color: black
 
 .delete-button
   a

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -45,7 +45,8 @@ div class="photo-index is-flex is-flex-wrap-wrap is-align-content-flex-start #{'
       data: { confirm: '投稿した写真も削除されます。よろしいですか？' }, class: 'is-size-6 has-text-grey'
   = link_to '戻る', books_path
 
-.photo-post-button-section.has-text-right
+.photo-post-button-section
   = link_to new_book_photo_path(@book), class: 'button is-warning' do
     span.icon
       i.fa.fa-plus.is-size-3
+    p.ml-1 = '写真を投稿する'


### PR DESCRIPTION
- Refs: #223 

## 概要
右下に写真投稿ボタンを設置したが、固定されていなかったので、写真の枚数が多い場合スクロールしないと写真投稿できない問題を解決した。

解決方法としては`position: fixed`を設定してボタンの位置を固定した
![image](https://user-images.githubusercontent.com/57053236/163782409-96ec3535-f4bf-4c6e-9b16-c7802b5f574b.png)
