### PR TITLE
プラバシーポリシーと利用規約に横幅の制限を持たせた

### DIFF
--- a/app/javascript/styles/_body.sass
+++ b/app/javascript/styles/_body.sass
@@ -9,6 +9,8 @@ body
     font-weight: bold
 main
   flex: 1
+  .content
+    max-width: 1024px
 
 .has-background-ecru
   background: #efede0

--- a/sample.js
+++ b/sample.js
@@ -1,0 +1,7 @@
+let result =
+1
++
+
+1
+
+co


### PR DESCRIPTION
- Refs: #225 

## 概要
画面幅の大きなデバイスで見た時にプライバシーポリシーや利用規約が横に伸びていってしまう問題があったため、画面の横幅に制限をかけて伸びないようにした。