### PR TITLE
ReadHistoriesテーブルのカラム名を変更した

### DIFF
--- a/app/controllers/read_histories_controller.rb
+++ b/app/controllers/read_histories_controller.rb
@@ -22,10 +22,10 @@ class ReadHistoriesController < ApplicationController
     event = Google::Apis::CalendarV3::Event.new(
       summary: read_history.summary,
       start: Google::Apis::CalendarV3::EventDateTime.new(
-        date: read_history.read_back_at
+        date: read_history.read_back_on
       ),
       end: Google::Apis::CalendarV3::EventDateTime.new(
-        date: read_history.read_back_at
+        date: read_history.read_back_on
       ),
       description: read_history.description
     )
@@ -35,6 +35,6 @@ class ReadHistoriesController < ApplicationController
   private
 
   def read_history_params
-    params.require(:read_history).permit(:summary, :read_back_at, :description)
+    params.require(:read_history).permit(:summary, :read_back_on, :description)
   end
 end

--- a/app/models/calendar_client.rb
+++ b/app/models/calendar_client.rb
@@ -21,10 +21,10 @@ class CalendarClient
     event = Google::Apis::CalendarV3::Event.new(
       summary: read_history.summary,
       start: Google::Apis::CalendarV3::EventDateTime.new(
-        date: read_history.read_back_at
+        date: read_history.read_back_on
       ),
       end: Google::Apis::CalendarV3::EventDateTime.new(
-        date: read_history.read_back_at
+        date: read_history.read_back_on
       ),
       description: read_history.description
     )

--- a/app/models/read_history.rb
+++ b/app/models/read_history.rb
@@ -4,14 +4,14 @@ class ReadHistory < ApplicationRecord
   belongs_to :book
   validates :summary, length: { maximum: 50 }, presence: true
   validates :description, length: { maximum: 300 }
-  validates :read_back_at, :book, presence: true
+  validates :read_back_on, :book, presence: true
   validate :date_to_read_back_should_be_after_today
 
   private
 
   def date_to_read_back_should_be_after_today
-    return unless read_back_at
+    return unless read_back_on
 
-    errors.add(:read_back_at, 'は今日より後の日付に設定してください') if read_back_at <= Time.zone.today
+    errors.add(:read_back_on, 'は今日より後の日付に設定してください') if read_back_on <= Time.zone.today
   end
 end

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -35,7 +35,7 @@
         tr
           th = Book.human_attribute_name(:title)
           th = Photo.human_attribute_name(:updated_at)
-          th = ReadHistory.human_attribute_name(:read_back_at)
+          th = ReadHistory.human_attribute_name(:read_back_on)
       tbody
         - @books.each do |book|
           tr
@@ -44,7 +44,7 @@
               span.photo-count.is-size-6.ml-4 = book.photos.count
 
             td.has-text-grey = last_update_of_photo(book)
-            td.has-text-grey = l(book.read_histories.last.read_back_at, format: :date) if book.read_histories.present?
+            td.has-text-grey = l(book.read_histories.last.read_back_on, format: :date) if book.read_histories.present?
   - else
     .blank-page.has-text-centered.has-text-grey
         .o-empty-message__text

--- a/app/views/read_histories/_form.html.slim
+++ b/app/views/read_histories/_form.html.slim
@@ -10,8 +10,8 @@
       = f.text_field :summary, class: 'input', value: "#{read_history.book.title}を読み返す日"
   .field
     .control
-      = f.label :read_back_at, class: 'label'
-      = f.date_field :read_back_at, class: 'input'
+      = f.label :read_back_on, class: 'label'
+      = f.date_field :read_back_on, class: 'input'
   .field
     .control
       = f.label :description, class: 'label'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,7 +13,7 @@ ja:
         updated_at: 投稿日
       read_history:
         summary: サマリー
-        read_back_at: 読み返す日
+        read_back_on: 読み返す日
         description: メモ
   time:
     formats:

--- a/db/migrate/20220420062844_rename_read_back_at_column_to_read_histories.rb
+++ b/db/migrate/20220420062844_rename_read_back_at_column_to_read_histories.rb
@@ -1,0 +1,5 @@
+class RenameReadBackAtColumnToReadHistories < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :read_histories, :read_back_at, :read_back_on
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_10_062326) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_20_062844) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_10_062326) do
   create_table "read_histories", force: :cascade do |t|
     t.string "summary", null: false
     t.text "description"
-    t.date "read_back_at", null: false
+    t.date "read_back_on", null: false
     t.bigint "book_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/read_histories.rb
+++ b/spec/factories/read_histories.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :read_history do
     summary { '本のタイトル' }
-    read_back_at { Time.zone.today + 1.day }
+    read_back_on { Time.zone.today + 1.day }
     description { '' }
     association :book
 
@@ -11,12 +11,12 @@ FactoryBot.define do
       summary { '' }
     end
 
-    trait :without_read_back_at do
-      read_back_at { '' }
+    trait :without_read_back_on do
+      read_back_on { '' }
     end
 
     trait :date_is_before_today do
-      read_back_at { Time.zone.today - 1.day }
+      read_back_on { Time.zone.today - 1.day }
     end
   end
 end

--- a/spec/models/read_history_spec.rb
+++ b/spec/models/read_history_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe ReadHistory, type: :model do
   end
 
   it '読み返す日が設定されていなければ無効な状態であること' do
-    read_history = FactoryBot.build(:read_history, :without_read_back_at)
+    read_history = FactoryBot.build(:read_history, :without_read_back_on)
     read_history.valid?
-    expect(read_history.errors[:read_back_at]).to include('を入力してください')
+    expect(read_history.errors[:read_back_on]).to include('を入力してください')
   end
 
   it '読み返す日を今日の日付よりも前に設定した場合無効な状態であること' do
     read_history = FactoryBot.build(:read_history, :date_is_before_today)
     read_history.valid?
-    expect(read_history.errors[:read_back_at]).to include('は今日より後の日付に設定してください')
+    expect(read_history.errors[:read_back_on]).to include('は今日より後の日付に設定してください')
   end
 end


### PR DESCRIPTION
- Refs: #228 

## 概要
`read_back_at`というカラムの型はdate型であった。
`read_back_at`だとdatetimeを扱うことが多いので`read_back_on`というカラム名に変更した。