### PR TITLE
[レビュー対応]不要なアクションへのアクセスを防ぐためにルーティングを整理した

### DIFF
--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -12,7 +12,7 @@
             p = '最終更新日: なし'
       = link_to '編集', edit_book_path(@book), class: 'button is-small is-responsive ml-3'
     .google-button.column.has-text-right
-      = link_to new_book_read_histories_path(@book), class: 'button is-info' do
+      = link_to new_book_read_history_path(@book), class: 'button is-info' do
         span.icon.mr-1
           i.fas.fa-calendar-alt
         = 'Googleカレンダーに読み返す日を設定する'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   get 'auth/failure', to: redirect('/')
   delete '/logout', to: 'sessions#destroy'
 
-  resource :retirement
+  resource :retirement, only: %i(new create)
 
   resources :books, except: %i(new) do
     resources :photos, only: %i(new create show update)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,6 @@ Rails.application.routes.draw do
 
   get '/auth/:provider/callback', to: 'sessions#create'
   get 'auth/failure', to: redirect('/')
-  get "oauth2callback", to:"read_histories#callback"
   delete '/logout', to: 'sessions#destroy'
 
   resource :retirement

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,6 @@ Rails.application.routes.draw do
 
   resources :books, except: %i(new) do
     resources :photos, only: %i(new create show update)
-    resource :read_histories, only: %i(new create)
+    resources :read_histories, only: %i(new create)
   end
 end

--- a/spec/system/read_histories.rb
+++ b/spec/system/read_histories.rb
@@ -12,7 +12,7 @@ RSpec.describe 'ReadHistories', type: :system, js: true do
       allow_any_instance_of(CalendarClient).to receive(:create_event).and_return(calendar_client_mock)
 
       sign_in_as book.user
-      visit new_book_read_histories_path(book)
+      visit new_book_read_history_path(book)
     end
 
     context 'サマリーの入力' do


### PR DESCRIPTION
- Refs: #229 

## 概要
`routes.rb`の中を見直した。
- 使われていないルーティングを削除
- onlyオプションで不要なアクションへのアクセスを防いだ
- read_historyのルーティングを単数から複数へ変更