### PR TITLE
写真一覧画面でフッターが非表示になるようにした 

### DIFF
--- a/app/javascript/styles/_body.sass
+++ b/app/javascript/styles/_body.sass
@@ -8,6 +8,7 @@ body
   h1
     font-weight: bold
 main
+  margin-bottom: 20px
   flex: 1
   .content
     max-width: 1024px

--- a/app/javascript/styles/_photo.sass
+++ b/app/javascript/styles/_photo.sass
@@ -34,11 +34,13 @@ div.photo-post-button-section
     height: 50px
     border-radius: 10px
     position: fixed
-    bottom: 40px
+    bottom: 50px
     right: 40px
     p
       color: black
 
-.delete-button
-  a
-    text-decoration-line: underline
+.is-flex.is-justify-content-space-between
+  margin-top: 130px
+  .delete-button
+    a
+      text-decoration-line: underline

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -24,6 +24,6 @@ html
         .notification.is-danger.is-light
           = flash.alert
       = yield
-    - unless current_page?(book_path)
+    - unless @book.present? && Book.exists?(@book.id)
       footer.footer.is-size-7
         = render 'shared/footer'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -24,5 +24,6 @@ html
         .notification.is-danger.is-light
           = flash.alert
       = yield
-    footer.footer.is-size-7
-      = render 'shared/footer'
+    - unless current_page?(book_path)
+      footer.footer.is-size-7
+        = render 'shared/footer'


### PR DESCRIPTION
- Refs: #236 

## 概要
写真を投稿すると画面がどんどん下に伸びていく仕様になっているのでフッターを非表示にするようにした。
また、フッターを非表示にしたことで写真投稿ボタンが戻るリンクに干渉するようになったのでボタンの位置を調整した。