### PR TITLE
アカウント削除に失敗したときフラッシュメッセージにその旨を表示するようにした

### DIFF
--- a/app/controllers/retirements_controller.rb
+++ b/app/controllers/retirements_controller.rb
@@ -4,9 +4,10 @@ class RetirementsController < ApplicationController
   def new; end
 
   def create
-    return unless current_user.destroy
-
+    current_user.destroy!
     reset_session
     redirect_to root_path, notice: 'アカウントを削除しました'
+  rescue ActiveRecord::RecordNotDestroyed
+    redirect_to books_path notice: 'アカウントの削除に失敗しました'
   end
 end


### PR DESCRIPTION
- Refs: #249 

## 概要
アカウント削除に失敗したとき、例外を補足し、エラーメッセージを表示するようにした。